### PR TITLE
Added autoload.ini

### DIFF
--- a/system/modules/clipboard/config/autoload.ini
+++ b/system/modules/clipboard/config/autoload.ini
@@ -1,0 +1,7 @@
+
+;;
+; Configure what you want the autoload creator to register
+;;
+register_namespaces = false
+register_classes    = true
+register_templates  = true


### PR DESCRIPTION
To active and use the extension within 3.5.6 I've added the autoload.ini. I've only checked that the extension works well with Articles and Templates - But thus far, everything seems fine.